### PR TITLE
Fixed Pipeline YAML and Project Name

### DIFF
--- a/services/base.go
+++ b/services/base.go
@@ -24,6 +24,7 @@ type Operation interface {
 }
 
 func createYaml(yaml, sourceOrg, sourceProject, targetOrg, targetProject string) string {
+	// used to update a YAML pipeline.  Will add the orgIdentifier and projectIdentifier if not found
 	var out string
 
 	if strings.Contains(yaml, "orgIdentifier: ") {
@@ -42,6 +43,7 @@ func createYaml(yaml, sourceOrg, sourceProject, targetOrg, targetProject string)
 }
 
 func createYamlQuotes(yaml, sourceOrg, sourceProject, targetOrg, targetProject string) string {
+	// used to update a YAML pipeline if quotes are defined.  Will add the orgIdentifier and projectIdentifier if not found
 	var out string
 
 	if strings.Contains(yaml, "orgIdentifier: ") {
@@ -58,6 +60,23 @@ func createYamlQuotes(yaml, sourceOrg, sourceProject, targetOrg, targetProject s
 
 	return out
 }
+
+func updateYaml(yaml, sourceOrg, sourceProject, targetOrg, targetProject string) string {
+	// used to only update a YAML pipeline. Will NOT add the orgIdentifier and projectIdentifier if not found
+	out := yaml 
+	
+	if strings.Contains(out, "\"orgIdentifier\": \""+sourceOrg+"\"") {
+		out = strings.ReplaceAll(out, "\"orgIdentifier\": \""+sourceOrg+"\"", "\"orgIdentifier\": \""+targetOrg+"\"")
+	}
+
+	if strings.Contains(out, "\"projectIdentifier\": \""+sourceProject+"\"") {
+		out = strings.ReplaceAll(out, "\"projectIdentifier\": \""+sourceProject+"\"", "\"projectIdentifier\": \""+targetProject+"\"")
+	}
+
+	return out
+}
+
+
 
 func handleErrorResponse(resp *resty.Response) error {
 	result := model.ErrorResponse{}

--- a/services/pipeline.go
+++ b/services/pipeline.go
@@ -56,7 +56,7 @@ func (c PipelineContext) Copy() error {
 
 		pipeData, err := c.api.getPipeline(c.sourceOrg, c.sourceProject, pipe.Identifier, c.logger)
 		if err == nil {
-			newYaml := createYaml(pipeData.YAMLPipeline, c.sourceOrg, c.sourceProject, c.targetOrg, c.targetProject)
+			newYaml := updateYaml(pipeData.YAMLPipeline, c.sourceOrg, c.sourceProject, c.targetOrg, c.targetProject)
 			err = c.api.createPipeline(c.targetOrg, c.targetProject, newYaml, c.logger)
 		}
 		if err != nil {

--- a/services/project.go
+++ b/services/project.go
@@ -99,7 +99,7 @@ func (c ProjectContext) Copy() error {
 
 	newProject := &model.Project{
 		Identifier:    c.targetProject,
-		Name:          c.targetProject,
+		Name:          sourceProject.Name,
 		Color:         sourceProject.Color,
 		Modules:       sourceProject.Modules,
 		Description:   sourceProject.Description,


### PR DESCRIPTION
Updated so that if the project name is not specified, it will use the source project name instead.  

Fixed issue where the pipeline was adding the projectIdentifier outside of the YAML pipeline which caused it to not show as valid YAML in the target project