### PR TITLE
Feat/project tags

### DIFF
--- a/model/project.go
+++ b/model/project.go
@@ -16,13 +16,13 @@ type GetProjectData struct {
 }
 
 type Project struct {
-	OrgIdentifier string        `json:"orgIdentifier"`
-	Identifier    string        `json:"identifier"`
-	Name          string        `json:"name"`
-	Color         string        `json:"color"`
-	Modules       []interface{} `json:"modules"`
-	Description   string        `json:"description"`
-	Tags          Tags          `json:"tags"`
+	OrgIdentifier string            `json:"orgIdentifier"`
+	Identifier    string            `json:"identifier"`
+	Name          string            `json:"name"`
+	Color         string            `json:"color"`
+	Modules       []interface{}     `json:"modules"`
+	Description   string            `json:"description"`
+	Tags          map[string]string `json:"tags"`
 }
 
 type ProjectWrapper struct {

--- a/operation/validateAndReport.go
+++ b/operation/validateAndReport.go
@@ -212,12 +212,12 @@ func ValidateAndLogCopy(cp Copy, logger *zap.Logger) bool {
 				zap.String("Source Project", cp.Source.Project),
 				zap.Error(err),
 			)
-			fmt.Printf( Red + "Error encountered while freezing project: '%v'.  Err: %v \n" + Reset, cp.Source.Project, err)
+			fmt.Printf(Red+"Error encountered while freezing project: '%v'.  Err: %v \n"+Reset, cp.Source.Project, err)
 			return false
 		}
 	} else {
-		fmt.Printf( Red + "Error encountered while copying project: '%v'. \n" + Reset, cp.Target.Project)
-		fmt.Printf( Red + "Source project: %v has not be froozen. \n" + Reset, cp.Source.Project)
+		fmt.Printf(Red+"Error encountered while copying project: '%v'. \n"+Reset, cp.Target.Project)
+		fmt.Printf(Red+"Source project: %v has not be froozen. \n"+Reset, cp.Source.Project)
 		return false
 	}
 


### PR DESCRIPTION
Updated how project tags were processed so they could be copied to the target project.  Updated so they were processed as a map of strings. 

Updated formatting on `operation/validateAndReport.go`